### PR TITLE
Re-pad the view on re-render while keyboard continues to show

### DIFF
--- a/KeyboardAvoidanceSwiftUI/KeyboardAdaptive.swift
+++ b/KeyboardAvoidanceSwiftUI/KeyboardAdaptive.swift
@@ -12,24 +12,38 @@ import Combine
 /// Note that the `KeyboardAdaptive` modifier wraps your view in a `GeometryReader`, 
 /// which attempts to fill all the available space, potentially increasing content view size.
 struct KeyboardAdaptive: ViewModifier {
+    private let rerender: AnyPublisher<Any, Never>
     @State private var bottomPadding: CGFloat = 0
-
+    
+    init(rerender: AnyPublisher<Any, Never>? = nil) {
+        var publishers = [Publishers.keyboardHeight.map { arg -> Any in arg }.eraseToAnyPublisher()]
+        if let rerender = rerender {
+            publishers.append(rerender)
+        }
+        self.rerender = Publishers.MergeMany(publishers).eraseToAnyPublisher()
+    }
+    
+    private func bottomPadding(forGeometry geometry: GeometryProxy) -> CGFloat {
+        let keyboardTop = geometry.frame(in: .global).height - Publishers.keyboardHeight.value
+        var focusedTextInputBottom = UIResponder.currentFirstResponder?.globalFrame?.maxY ?? 0
+        focusedTextInputBottom += bottomPadding / 2
+        return 2 * max(0, focusedTextInputBottom - keyboardTop - geometry.safeAreaInsets.bottom)
+    }
+    
     func body(content: Content) -> some View {
         GeometryReader { geometry in
             content
                 .padding(.bottom, self.bottomPadding)
-                .onReceive(Publishers.keyboardHeight) { keyboardHeight in
-                    let keyboardTop = geometry.frame(in: .global).height - keyboardHeight
-                    let focusedTextInputBottom = UIResponder.currentFirstResponder?.globalFrame?.maxY ?? 0
-                    self.bottomPadding = max(0, focusedTextInputBottom - keyboardTop - geometry.safeAreaInsets.bottom)
-            }
-            .animation(.easeOut(duration: 0.16))
+                .onReceive(self.rerender, perform: { _ in
+                    self.bottomPadding = self.bottomPadding(forGeometry: geometry)
+                })
+                .animation(.easeOut(duration: 0.16))
         }
     }
 }
 
 extension View {
-    func keyboardAdaptive() -> some View {
-        ModifiedContent(content: self, modifier: KeyboardAdaptive())
+    func keyboardAdaptive(rerender: AnyPublisher<Any, Never>? = nil) -> some View {
+        ModifiedContent(content: self, modifier: KeyboardAdaptive(rerender: rerender))
     }
 }

--- a/KeyboardAvoidanceSwiftUI/KeyboardHeightPublisher.swift
+++ b/KeyboardAvoidanceSwiftUI/KeyboardHeightPublisher.swift
@@ -9,16 +9,22 @@
 import Combine
 import UIKit
 
+fileprivate var keyboardUpdates: AnyCancellable?
+fileprivate let keyboardHeightPublisher: CurrentValueSubject<CGFloat, Never> = {
+    let subject = CurrentValueSubject<CGFloat, Never>(0)
+    
+    let willShow = NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
+        .map { $0.keyboardHeight }
+    let willHide = NotificationCenter.default.publisher(for: UIApplication.keyboardWillHideNotification)
+        .map { _ in CGFloat(0) }
+    keyboardUpdates = Publishers.MergeMany(willShow, willHide).assign(to: \.value, on: subject)
+
+    return subject
+}()
+
 extension Publishers {
-    static var keyboardHeight: AnyPublisher<CGFloat, Never> {
-        let willShow = NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
-            .map { $0.keyboardHeight }
-        
-        let willHide = NotificationCenter.default.publisher(for: UIApplication.keyboardWillHideNotification)
-            .map { _ in CGFloat(0) }
-        
-        return MergeMany(willShow, willHide)
-            .eraseToAnyPublisher()
+    static var keyboardHeight: CurrentValueSubject<CGFloat, Never> {
+        keyboardHeightPublisher
     }
 }
 


### PR DESCRIPTION
The current implementation will only update the padding if the keyboard shows or hides. But what if the view re-renders, moving the first responder up or down, while the keyboard is showing?

This happens in my app, which is a tutorial for setting up a custom keyboard. My view is like this:

```swift
struct SwitchToKeyboardView: View {
    @EnvironmentObject var keyboardState: KeyboardState

    @State var dummyText = ""
    @State var dummyInputIsEditing = true
    
    @ViewBuilder
    var body: some View {
        VStack {
            if keyboardState.hasBeenOpened {
                Text("Great!").font(.title)
                Text("Searchboard is now ready")
                Text("to use in any app.")
            } else {
                Text("Tap and hold the ") + Text("Globe").bold() + Text(" icon")
                Text("Tap ") + Text("Searchboard").bold() + Text(" to switch keyboards")
            }
            // Use an invisible text view to bring up the keyboard and to
            // permit the keyboard to tell us that we're opened (see
            // `KeyboardState`). We don't use a text field since you can't
            // force those to become first responder
            // https://stackoverflow.com/a/56508132/495611 . Keep the text
            // view visible even after the user has switched, the first
            // time that they switch, so that they can play around with the
            // keyboard.
            TextView(text: $dummyText, isEditing: $dummyInputIsEditing).frame(width: 0, height: 0, alignment: .center)
        }
        .keyboardAdaptive()
    }
}

```

Where `TextView` is an instance of [this](https://github.com/kenmueller/TextView/). I won't get into the implementation of `KeyboardState` unless you like, but I have a mechanism where once my custom keyboard opens, it causes `keyboardState.hasBeenOpened` to become `true`, asynchronously with respect to the keyboard changing.

You may notice that the text above the field grows bigger when the keyboard has been opened, so the padding needs to increase. But it doesn't, because the update comes in after the keyboard has already changed.

-----------------

Here's a PR that's a stab at re-rendering the `ViewModifier` when the keyboard height changes _or_ when a client-provided publisher fires. In my case, that publisher is a binding to `keyboardState.hasBeenOpened`: I change my `.keyboardAdaptive()` invocation to look like

```swift
.keyboardAdaptive(rerender: keyboardState.$hasBeenOpened.map({ arg -> Any in
    arg
}).eraseToAnyPublisher())
```

There are a _bunch_ of things I don't like about this approach, but I figured I'd put it up to start a conversation.